### PR TITLE
docs: add issue labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -2,8 +2,8 @@
 name: Bug
 about: To report a bug found in the project's working.
 title: ''
-labels: ''
-assignees: ''
+labels: '🚦 status: awaiting triage'
+assignees: 'eddiejaoude'
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/docs.md
+++ b/.github/ISSUE_TEMPLATE/docs.md
@@ -2,8 +2,8 @@
 name: Docs
 about: Found a typo in docs? You can use this one!
 title: ''
-labels: ''
-assignees: ''
+labels: '🚦 status: awaiting triage'
+assignees: 'eddiejaoude'
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/ideas.md
+++ b/.github/ISSUE_TEMPLATE/ideas.md
@@ -2,8 +2,8 @@
 name: Ideas
 about: Have a new idea/feature for the project?
 title: ''
-labels: ''
-assignees: ''
+labels: '🚦 status: awaiting triage'
+assignees: 'eddiejaoude'
 
 ---
 


### PR DESCRIPTION
#### Proposed Changes

This PR will allow new issues to be automatically labelled with the `status: awaiting triage` label and assign @eddiejaoude to the issue. This workflow will ensure that issues are properly triaged and discussed before labelling and opening up to contribution.

Additionally, this PR disallows the creation of blank issues (issues without a template).

<!-- include an screenshot if applicable -->
#### Screenshots
